### PR TITLE
Feature/auth create user

### DIFF
--- a/src/consts.ts
+++ b/src/consts.ts
@@ -3,3 +3,4 @@ export const SALT_SEPARATOR = ':';
 export const PASSWORD_MIN_LENGTH = 6;
 export const INTERNAL_SERVER_ERROR_CODE = 500;
 export const BAD_REQUEST_ERROR_CODE = 400;
+export const UNAUTHORIZED_ERROR_CODE = 401;

--- a/src/exceptions/custom-error.ts
+++ b/src/exceptions/custom-error.ts
@@ -1,8 +1,10 @@
+export type AdditionalInfo = string | object;
+
 export class CustomError extends Error {
   constructor(
     public code: number,
     public message: string,
-    public additionalInfo?: string | object,
+    public additionalInfo?: AdditionalInfo,
     public name: string = 'CustomError',
   ) {
     super(message);

--- a/src/exceptions/unauthenticated-error.ts
+++ b/src/exceptions/unauthenticated-error.ts
@@ -1,0 +1,8 @@
+import { UNAUTHORIZED_ERROR_CODE } from '../consts';
+import { AdditionalInfo, CustomError } from './custom-error';
+
+export class UnauthenticatedError extends CustomError {
+  constructor(public message: string, public additionalInfo?: AdditionalInfo, public name = 'UnauthorizedError') {
+    super(UNAUTHORIZED_ERROR_CODE, message, additionalInfo, name);
+  }
+}

--- a/src/resolvers/user.resolver.ts
+++ b/src/resolvers/user.resolver.ts
@@ -5,15 +5,15 @@ import { User } from '../entities/user.entity';
 import { CustomValidationError } from '../exceptions/custom-validation-error';
 import { InvalidLoginCredentials } from '../exceptions/invalid-login-credentials';
 import { InvalidPassword } from '../exceptions/invalid-password';
-import { GraphqlContext } from '../server';
-import { signJwt, verifyRequestAuthentication } from '../utils/auth';
+import { signJwt, validateJwt } from '../utils/auth';
+import { GraphqlContext } from '../utils/context';
 import { Env } from '../utils/env';
 import { checkPassword, hashPassword, isPasswordValid, rulesErrorMessage } from '../utils/password';
 
 export const userResolver = {
   Mutation: {
-    createUser: async function (_: never, { user }: { user: User }, { expressContext }: GraphqlContext) {
-      verifyRequestAuthentication(expressContext.req);
+    createUser: async function (_: never, { user }: { user: User }, { jwt }: GraphqlContext) {
+      validateJwt(jwt);
 
       validatePassword(user);
       user.password = await hashPassword(user.password);

--- a/src/server.ts
+++ b/src/server.ts
@@ -2,7 +2,6 @@ import { ApolloServerPluginDrainHttpServer, Config } from 'apollo-server-core';
 import { ApolloServer, ExpressContext } from 'apollo-server-express';
 import express from 'express';
 import http from 'http';
-import { DataSource } from 'typeorm';
 import { setupDataSource } from './data-source';
 import { helloResolver } from './resolvers/hello.resolver';
 import { userResolver } from './resolvers/user.resolver';
@@ -12,7 +11,7 @@ import { Env } from './utils/env';
 import { formatError } from './utils/format-error';
 
 export interface GraphqlContext {
-  dataSource: DataSource;
+  expressContext: ExpressContext;
 }
 
 export async function setupServer() {
@@ -45,6 +44,9 @@ export async function startApolloServer(
     typeDefs,
     resolvers,
     formatError,
+    context: (expressContext) => ({
+      expressContext,
+    }),
     plugins: [ApolloServerPluginDrainHttpServer({ httpServer })],
   });
 

--- a/src/server.ts
+++ b/src/server.ts
@@ -7,12 +7,9 @@ import { helloResolver } from './resolvers/hello.resolver';
 import { userResolver } from './resolvers/user.resolver';
 import { helloTypeDef } from './types/hello.type';
 import { userTypeDef } from './types/user.type';
+import { context } from './utils/context';
 import { Env } from './utils/env';
 import { formatError } from './utils/format-error';
-
-export interface GraphqlContext {
-  expressContext: ExpressContext;
-}
 
 export async function setupServer() {
   const server = await configAndInitilizeServer();
@@ -44,9 +41,7 @@ export async function startApolloServer(
     typeDefs,
     resolvers,
     formatError,
-    context: (expressContext) => ({
-      expressContext,
-    }),
+    context,
     plugins: [ApolloServerPluginDrainHttpServer({ httpServer })],
   });
 

--- a/src/utils/auth.ts
+++ b/src/utils/auth.ts
@@ -10,9 +10,8 @@ export interface TokenPayload {
   birthDate: string;
 }
 
-export function verifyRequestAuthentication(request: Request): TokenPayload {
-  const authHeader = request.headers.authorization;
-  if (!authHeader) {
+export function validateJwt(token: string | undefined): TokenPayload {
+  if (!token) {
     throw new UnauthenticatedError(
       'You must be logged in',
       'No jwt token was provided in the Authorization header',
@@ -21,8 +20,6 @@ export function verifyRequestAuthentication(request: Request): TokenPayload {
   }
 
   try {
-    const token = extractToken(authHeader);
-
     return verifyJwt(token) as TokenPayload;
   } catch (error) {
     if (error instanceof TokenExpiredError) {
@@ -35,6 +32,11 @@ export function verifyRequestAuthentication(request: Request): TokenPayload {
 
     throw error;
   }
+}
+
+export function extractJwtFromRequest(request: Request): string | undefined {
+  const authHeader = request.headers.authorization;
+  return authHeader === undefined ? undefined : extractToken(authHeader);
 }
 
 function extractToken(authHeader: string) {

--- a/src/utils/auth.ts
+++ b/src/utils/auth.ts
@@ -1,0 +1,50 @@
+import { Request } from 'express';
+import jwt, { JsonWebTokenError, TokenExpiredError } from 'jsonwebtoken';
+import { UnauthenticatedError } from '../exceptions/unauthenticated-error';
+import { Env } from './env';
+
+export interface TokenPayload {
+  id: number;
+  name: string;
+  email: string;
+  birthDate: string;
+}
+
+export function verifyRequestAuthentication(request: Request): TokenPayload {
+  const authHeader = request.headers.authorization;
+  if (!authHeader) {
+    throw new UnauthenticatedError(
+      'You must be logged in',
+      'No jwt token was provided in the Authorization header',
+      'NoJwtToken',
+    );
+  }
+
+  try {
+    const token = extractToken(authHeader);
+
+    return verifyJwt(token) as TokenPayload;
+  } catch (error) {
+    if (error instanceof TokenExpiredError) {
+      throw new UnauthenticatedError('Login expired', 'Jwt token is expired', 'JwtTokenExpired');
+    }
+
+    if (error instanceof JsonWebTokenError) {
+      throw new UnauthenticatedError('You must be logged in', 'Invalid jwt token', 'InvalidJwtToken');
+    }
+
+    throw error;
+  }
+}
+
+function extractToken(authHeader: string) {
+  return authHeader.replace('Bearer', '').trim();
+}
+
+export function signJwt(payload: string | Buffer | object, options?: jwt.SignOptions) {
+  return jwt.sign(payload, Env.JWT_SECRET, options);
+}
+
+export function verifyJwt(token: string, options?: jwt.VerifyOptions & { complete?: false }) {
+  return jwt.verify(token, Env.JWT_SECRET, options);
+}

--- a/src/utils/context.ts
+++ b/src/utils/context.ts
@@ -1,0 +1,11 @@
+import { ContextFunction } from 'apollo-server-core';
+import { ExpressContext } from 'apollo-server-express';
+import { extractJwtFromRequest } from './auth';
+
+export interface GraphqlContext {
+  jwt: string | undefined;
+}
+
+export const context: ContextFunction<ExpressContext, GraphqlContext> = (expressContext) => ({
+  jwt: extractJwtFromRequest(expressContext.req),
+});

--- a/src/utils/graphql.ts
+++ b/src/utils/graphql.ts
@@ -1,7 +1,14 @@
-import axios from 'axios';
+import axios, { AxiosRequestHeaders } from 'axios';
 
-export function makeGraphqlResquest(url: string, query: string, variables: unknown = undefined) {
+export function makeGraphqlResquest(
+  url: string,
+  query: string,
+  variables: object = undefined,
+  jwtToken?: string,
+  headers?: AxiosRequestHeaders,
+) {
   variables = variables ?? {};
+  const authorization = jwtToken ? { Authorization: `Bearer ${jwtToken}` } : undefined;
   return axios.post(
     url,
     {
@@ -11,6 +18,8 @@ export function makeGraphqlResquest(url: string, query: string, variables: unkno
     {
       headers: {
         'content-type': 'application/json',
+        ...authorization,
+        ...headers,
       },
     },
   );

--- a/test/user/login.test.ts
+++ b/test/user/login.test.ts
@@ -3,6 +3,7 @@ import jwt from 'jsonwebtoken';
 import { BAD_REQUEST_ERROR_CODE } from '../../src/consts';
 import { dataSource } from '../../src/data-source';
 import { User } from '../../src/entities/user.entity';
+import { verifyJwt } from '../../src/utils/auth';
 import { Env } from '../../src/utils/env';
 import { makeGraphqlResquest } from '../../src/utils/graphql';
 import { hashPassword } from '../../src/utils/password';
@@ -25,7 +26,7 @@ export const loginTests = (testServerUrl: string) => {
       const { id } = await dataSource.manager.save(User, user);
 
       const mutationResponse = await makeLoginMutationRequest({ email: user.email, password: unhashedPassword });
-      const tokenPayload = jwt.verify(mutationResponse.data.data.login.token, Env.JWT_SECRET) as jwt.JwtPayload;
+      const tokenPayload = verifyJwt(mutationResponse.data.data.login.token) as jwt.JwtPayload;
       const tokenDuration = tokenPayload.exp - tokenPayload.iat;
 
       expect(mutationResponse.data.errors).to.be.undefined;
@@ -58,7 +59,7 @@ export const loginTests = (testServerUrl: string) => {
         password: unhashedPassword,
         rememberMe: true,
       });
-      const tokenPayload = jwt.verify(mutationResponse.data.data.login.token, Env.JWT_SECRET) as jwt.JwtPayload;
+      const tokenPayload = verifyJwt(mutationResponse.data.data.login.token) as jwt.JwtPayload;
       const tokenDuration = tokenPayload.exp - tokenPayload.iat;
 
       expect(mutationResponse.data.errors).to.be.undefined;


### PR DESCRIPTION
+ Mutation `createUser` agora requer um jwt válido no header `Authorization`
+ Adiocionado novos testes de autorização na mutation `createUser`.

![image](https://user-images.githubusercontent.com/49251043/167721599-e5fe36f3-170f-4612-8697-90d513b06ae3.png)
